### PR TITLE
Migration rollback and change administrator seeder

### DIFF
--- a/database/migrations/2021_06_10_095433_add_foreign_key_to_petugas_kebersihan.php
+++ b/database/migrations/2021_06_10_095433_add_foreign_key_to_petugas_kebersihan.php
@@ -29,7 +29,8 @@ class AddForeignKeyToPetugasKebersihan extends Migration
     public function down()
     {
         Schema::table('petugas_kebersihan', function (Blueprint $table) {
-            //
+            $table->dropConstrainedForeignId('id_administrator');
+            $table->dropConstrainedForeignId('id_truk');
         });
     }
 }

--- a/database/migrations/2021_06_10_100059_add_foreign_key_to_data_diri_petugas.php
+++ b/database/migrations/2021_06_10_100059_add_foreign_key_to_data_diri_petugas.php
@@ -27,7 +27,7 @@ class AddForeignKeyToDataDiriPetugas extends Migration
     public function down()
     {
         Schema::table('data_diri_petugas', function (Blueprint $table) {
-            //
+            $table->dropConstrainedForeignId('id_petugas');
         });
     }
 }

--- a/database/migrations/2021_06_10_100223_add_foreign_key_to_kendaraan_pengangkut_sampah.php
+++ b/database/migrations/2021_06_10_100223_add_foreign_key_to_kendaraan_pengangkut_sampah.php
@@ -27,7 +27,7 @@ class AddForeignKeyToKendaraanPengangkutSampah extends Migration
     public function down()
     {
         Schema::table('kendaraan_pengangkut_sampah', function (Blueprint $table) {
-            //
+            $table->dropConstrainedForeignId('id_antares');
         });
     }
 }

--- a/database/migrations/2021_06_10_100332_add_foreign_key_to_tempat_sampah.php
+++ b/database/migrations/2021_06_10_100332_add_foreign_key_to_tempat_sampah.php
@@ -29,7 +29,9 @@ class AddForeignKeyToTempatSampah extends Migration
     public function down()
     {
         Schema::table('tempat_sampah', function (Blueprint $table) {
-            //
+            $table->dropConstrainedForeignId('id_administrator');
+            $table->dropConstrainedForeignId('id_truk');
+            $table->dropConstrainedForeignId('id_antares');
         });
     }
 }

--- a/database/migrations/2021_06_10_100520_add_foreign_key_to_lokasi.php
+++ b/database/migrations/2021_06_10_100520_add_foreign_key_to_lokasi.php
@@ -27,7 +27,7 @@ class AddForeignKeyToLokasi extends Migration
     public function down()
     {
         Schema::table('lokasi', function (Blueprint $table) {
-            //
+            $table->dropConstrainedForeignId('id_tempat_sampah');
         });
     }
 }

--- a/database/migrations/2021_06_10_100616_add_foreign_key_to_log_pengambilan_sampah.php
+++ b/database/migrations/2021_06_10_100616_add_foreign_key_to_log_pengambilan_sampah.php
@@ -28,7 +28,8 @@ class AddForeignKeyToLogPengambilanSampah extends Migration
     public function down()
     {
         Schema::table('log_pengambilan_sampah', function (Blueprint $table) {
-            //
+            $table->dropConstrainedForeignId('id_tempat_sampah');
+            $table->dropConstrainedForeignId('id_truk');
         });
     }
 }

--- a/database/migrations/2021_06_10_100726_add_foreign_key_to_antares.php
+++ b/database/migrations/2021_06_10_100726_add_foreign_key_to_antares.php
@@ -29,7 +29,8 @@ class AddForeignKeyToAntares extends Migration
     public function down()
     {
         Schema::table('antares', function (Blueprint $table) {
-            //
+            $table->dropConstrainedForeignId('id_tempat_sampah');
+            $table->dropConstrainedForeignId('id_truk');
         });
     }
 }

--- a/database/seeders/AdministratorSeeder.php
+++ b/database/seeders/AdministratorSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-
+use App\Models\Administrator;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
@@ -16,7 +16,7 @@ class AdministratorSeeder extends Seeder
      */
     public function run()
     {
-        DB::table('administrator')->insert([
+        Administrator::insert([
             'username' => 'admin',
             'password' => Hash::make('admin'),
         ]);

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,6 +13,6 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        // \App\Models\User::factory(10)->create();
+        $this->call(AdministratorSeeder::class);
     }
 }


### PR DESCRIPTION
Using Eloquent instead of DB Query for inserting an administrator on the seeder, and can do a rollback from migration